### PR TITLE
query string coming in as data.content

### DIFF
--- a/library.js
+++ b/library.js
@@ -226,12 +226,12 @@ Elasticsearch.search = function(data, callback) {
 					queries: [
 						{
 							match: {
-								content: escapeSpecialChars(data.query)
+								content: escapeSpecialChars(data.content)
 							}
 						},
 						{
 							match: {
-								title: escapeSpecialChars(data.query)
+								title: escapeSpecialChars(data.content)
 							}
 						}
 					]


### PR DESCRIPTION
```js
	18 | escapeSpecialChars = function(s) {
	19 | ...
```
receives ```s = undefined``` and fails in nodeBB-0.7

Payload on filter:search.query was changed.

https://community.nodebb.org/topic/4654/non-latin-search-on-nodebb/